### PR TITLE
Add builtin not indexed in go builtin list

### DIFF
--- a/src/script_noxscript_builtins.go
+++ b/src/script_noxscript_builtins.go
@@ -349,6 +349,7 @@ var noxScriptBuiltins = []func() int{
 	84:  wrapScriptC(C.nox_script_getMaxHP_513DB0),
 	85:  wrapScriptC(C.nox_script_restoreHP_513DF0),
 	86:  wrapScriptC(C.nox_script_getDistance_513E20),
+	87:  wrapScriptC(C.nox_script_canInteract_513E80),
 	88:  nox_script_fn58_513F10,
 	89:  nox_script_fn59_513F20,
 	90:  nox_script_fn5A_513F30,


### PR DESCRIPTION
The index of builtin functions should be same between Go and C scripts, but Go scripts is missing one script at index 87.

C scripts reference: https://github.com/noxworld-dev/opennox/blob/149f14940c151369cd9808583e9c43ab5b013adb/src/server__script__builtin.c#L3411

This commit fix it by adding the missing script. Confirmed the updated list has 211 functions which is same as C version. (not confirmed the equality of individual list items, haha)
Fixes #524 

## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.
