### PR TITLE
Make build work with both Go 1.18 and 1.19

### DIFF
--- a/src/internal/noxbuild/main.go
+++ b/src/internal/noxbuild/main.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -130,8 +129,8 @@ func goBuild(cmd string, bin string, opts *buildOpts) error {
 		args = []string{
 			goBin, "build", "-v",
 			`-ldflags=` + strings.Join(LDFLAGS, " "),
-			"-gcflags=" + strconv.Quote(GCFLAGS),
-			"-asmflags=" + strconv.Quote(ASMFLAGS),
+			"-gcflags=" + GCFLAGS,
+			"-asmflags=" + ASMFLAGS,
 		}
 	)
 	envs = append(envs,


### PR DESCRIPTION
Removing quote escape made the build work for both versions. Tested using: 1.18: docker ubuntu:22.04
1.19: Arch linux as host os

Why it works? : I'm not very sure, but the code is using exec.command, which may call syscall exec() family so no escaping is needed. (unlike shell, which parse the command first then call exec)

Fixes #523

<!--
Describe what your PR changes and why. Please link related issues.

Make sure to split large changes into separate commits to allow bisecting in the future.

Ideally each commit should include one of the following (but not everything at once!):

- Rename of variables/functions.
- Rename of struct fields.
- Fixes to function signatures.
- Reconstruction of data structures.
- Reconstruction of functions.
-->


## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.
