### PR TITLE
Simplify direction related math functions

### DIFF
--- a/src/noxmath.go
+++ b/src/noxmath.go
@@ -6,29 +6,18 @@ import (
 	"github.com/noxworld-dev/opennox-lib/types"
 )
 
+// nox_xxx_math_509ED0 converts arbitrary point into angle value which is integer ranged 0-255.
 func nox_xxx_math_509ED0(p types.Pointf) int32 {
 	v := int32((math.Atan2(float64(p.Y), float64(p.X))+6.2831855)*40.743664 + 0.5)
 	return nox_xxx_math_roundDir(v)
 }
 
 func nox_xxx_math_roundDir(v int32) int32 {
-	if v < 0 {
-		v += int32(uint32(255-v) >> 8 << 8)
-	}
-	if v >= 256 {
-		v -= int32(uint32(v) >> 8 << 8)
-	}
-	return v
+	return int32(uint8(v))
 }
 
 func nox_xxx_math_roundDirI16(v int16) uint16 {
-	if v < 0 {
-		v += int16((uint32(255-v) >> 8) << 8)
-	}
-	if v >= 256 {
-		v -= int16((uint32(v) >> 8) << 8)
-	}
-	return uint16(v)
+	return uint16(uint8(v))
 }
 
 func sincosDir(d byte) (cos, sin float32) { // 194136, 194140


### PR DESCRIPTION
Found the code is unnecessarily complex maybe due to compiler optimization.

See below code for verification.

```
package main

import (
	"fmt"
        "math/rand"
)

func nox_xxx_math_roundDir(v int32) int32 {
	if v < 0 {
		v += int32(uint32(255-v) >> 8 << 8)
	}
	if v >= 256 {
		v -= int32(uint32(v) >> 8 << 8)
	}
	return v
}

func nox_xxx_math_roundDirI16(v int16) uint16 {
	if v < 0 {
		v += int16((uint32(255-v) >> 8) << 8)
	}
	if v >= 256 {
		v -= int16((uint32(v) >> 8) << 8)
	}
	return uint16(v)
}

func test[Num int16 | int32](v Num) uint8 {
  return uint8(v)
}

func main() {
  for i := 1; i <= 10000000; i++ {
    v0 := rand.Int31()
    if nox_xxx_math_roundDir(v0) != int32(uint16(v0 & 0xff)) {
      fmt.Printf("%d\n", v0);
      return 
    }
    if nox_xxx_math_roundDir(-v0) != int32(uint16(-v0 & 0xff)) {
      fmt.Printf("%d\n", v0);
      return 
    }
    if nox_xxx_math_roundDirI16(int16(v0)) != uint16(v0 & 0xff) {
      fmt.Printf("%d\n", v0);
      return 
    }
    if nox_xxx_math_roundDirI16(-int16(v0)) != uint16(-v0 & 0xff) {
      fmt.Printf("%d\n", v0);
      return 
    }
    if nox_xxx_math_roundDir(v0) != int32(test(v0)) || nox_xxx_math_roundDir(-v0) != int32(test(-v0)) {
      fmt.Printf("%d\n", v0);
      return
    }
    if nox_xxx_math_roundDirI16(int16(v0)) != uint16(test(v0)) || nox_xxx_math_roundDirI16(-int16(v0)) != uint16(test(-v0)) {
      fmt.Printf("%d\n", v0);
      return
    }
  }
}
```


## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.
