### PR TITLE
Fix incorrect usage of playerAnimGetFrameRange

### DIFF
--- a/src/object_update.go
+++ b/src/object_update.go
@@ -433,7 +433,7 @@ func (s *Server) unitUpdatePlayerImplA(u *Unit) (a1, v68 bool, _ bool) {
 		ud.Field59_0 = 0
 		return a1, v68, true
 	case 0xE:
-		_, v69 := playerAnimGetFrameRange(33)
+		v69, _ := playerAnimGetFrameRange(33)
 		ud.Field59_0 = uint8(v69 - 1)
 		if int(s.Frame())-int(u.Field34) > int(s.TickRate()) {
 			nox_xxx_playerSetState_4FA020(u, 13)
@@ -448,7 +448,7 @@ func (s *Server) unitUpdatePlayerImplA(u *Unit) (a1, v68 bool, _ bool) {
 		}
 		return a1, v68, true
 	case 0x10:
-		_, v69 := playerAnimGetFrameRange(40)
+		v69, _ := playerAnimGetFrameRange(40)
 		ud.Field59_0 = uint8(v69 - 1)
 		return a1, v68, true
 	case 0x11:
@@ -486,14 +486,14 @@ func (s *Server) unitUpdatePlayerImplA(u *Unit) (a1, v68 bool, _ bool) {
 		}
 		return a1, v68, true
 	case 0x15:
-		v67, v69 := playerAnimGetFrameRange(30)
+		v69, v67 := playerAnimGetFrameRange(30)
 		ud.Field59_0 = uint8((int(s.Frame()) - int(u.Field34)) / (v67 + 1))
 		if int(ud.Field59_0) >= v69 {
 			nox_xxx_playerSetState_4FA020(u, 13)
 		}
 		return a1, v68, true
 	case 0x16:
-		_, v69 := playerAnimGetFrameRange(31)
+		v69, _ := playerAnimGetFrameRange(31)
 		ud.Field59_0 = uint8(v69 - 1)
 		return a1, v68, true
 	case 0x17:


### PR DESCRIPTION
Original C code:
https://github.com/noxworld-dev/opennox/blob/fbfe4ab0af102962fef696123c00ea3a581e6c3d/src/GAME4.c#L1879

Can find:
```c
nox_xxx_animPlayerGetFrameRange_4F9F90(..., &v67, &v69); 
nox_xxx_animPlayerGetFrameRange_4F9F90(..., &v69, &v67); 
```

(Had mixed use of v67 and v69)

Which were all ported to same:

```go
v67, v69 := playerAnimGetFrameRange(...)
```
(second variant were not ported correctly)

This commit fixes params order properly using the order from C code.

<!--
Describe what your PR changes and why. Please link related issues.

Make sure to split large changes into separate commits to allow bisecting in the future.

Ideally each commit should include one of the following (but not everything at once!):

- Rename of variables/functions.
- Rename of struct fields.
- Fixes to function signatures.
- Reconstruction of data structures.
- Reconstruction of functions.
-->


## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.
