### PR TITLE
moved the setting of h.modkey to its own case statement

### DIFF
--- a/src/client/input/text.go
+++ b/src/client/input/text.go
@@ -26,21 +26,22 @@ func (h *Handler) SetLanguage(code int) { // nox_xxx_initKeyboard_47FB10
 	}
 	h.modKey = 0
 	var m map[keybind.Key]inputCharMap
+
+	switch code {
+	case 1, 2, 3, 5:
+		h.modKey = 0xb8
+	}
 	switch code {
 	case 0, 4, 6, 7, 8, 9:
 		m = noxInputMapLang0
 	case 1:
 		m = noxInputMapLang1
-		h.modKey = 0xb8
 	case 2:
 		m = noxInputMapLang2
-		h.modKey = 0xb8
 	case 3:
 		m = noxInputMapLang3
-		h.modKey = 0xb8
 	case 5:
 		m = noxInputMapLang5
-		h.modKey = 0xb8
 	}
 	for k, v := range m {
 		h.textMap[k] = v


### PR DESCRIPTION
Moved the setting of `h.modkey` in `client/input/text.go` to a separate case statement in order to neaten the code.

## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.
