### PR TITLE
Add the LIBGL environment variable for snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,9 @@ version-script: |
 architectures:
   - build-on: i386
     run-on: [amd64]
+    
+environment:
+  LIBGL_DRIVERS_PATH: $SNAP/usr/lib/i386-linux-gnu/dri
 
 apps:
   opennox:


### PR DESCRIPTION
This should fix the libGL error in the snap package.

#573 

## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.
