### PR TITLE
Corrected dependency in Linux build documentation

### DIFF
--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -4,7 +4,7 @@ This is the main build procedure for Linux version.
 
 ## Installing Go compiler
 
-Your Go installation must be at least version 1.19.
+Your Go installation must be at least version 1.20.
 
 If you have the supported version in your repository, you can install Go from there (`golang` package).
 

--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -17,7 +17,7 @@ See [official docs](https://golang.org/doc/install).
 ## Installing C compiler
 
 ```bash
-sudo apt install gcc
+sudo apt install gcc-multilib
 ```
 
 ## Installing other dependencies

--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -6,20 +6,13 @@ This is the main build procedure for Linux version.
 
 Your Go installation must be at least version 1.19.
 
-### Fastest way
+If you have the supported version in your repository, you can install Go from there (`golang` package).
 
-For Debian-based systems
-```
-sudo apt install golang
-```
-Snap install
+Otherwise, use Snap version
 ```bash
 sudo snap install --classic go
 ```
-
-### Longer way
-
-See [official docs](https://golang.org/doc/install).
+or see [official docs](https://golang.org/doc/install) for manual installation.
 
 ## Installing C compiler
 

--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -4,8 +4,15 @@ This is the main build procedure for Linux version.
 
 ## Installing Go compiler
 
+Your Go installation must be at least version 1.19.
+
 ### Fastest way
 
+For Debian-based systems
+```
+sudo apt install golang
+```
+Snap install
 ```bash
 sudo snap install --classic go
 ```
@@ -25,7 +32,7 @@ sudo apt install gcc-multilib
 ```bash
 sudo dpkg --add-architecture i386
 sudo apt update
-sudo apt install libsdl2-dev libsdl2-dev:i386 libopenal-dev libopenal-dev:i386
+sudo apt install libsdl2-dev:i386 libopenal-dev:i386
 ```
 
 ## Building


### PR DESCRIPTION
<!--
Describe what your PR changes and why. Please link related issues.

Make sure to split large changes into separate commits to allow bisecting in the future.

Ideally each commit should include one of the following (but not everything at once!):

- Rename of variables/functions.
- Rename of struct fields.
- Fixes to function signatures.
- Reconstruction of data structures.
- Reconstruction of functions.
-->


## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.

## PR explanation

This PR changes some prerequisites for building procedure for Linux.
1. Without installing `gcc-multilib`, `gcc` cannot compile 32 bit code at all. `gcc-multilib` depends on `gcc`, so no need to require gcc explicitly
2. Removed libsdl2 and openal. We don't need 64 bit libraries to compile 32 bit binary.
3. By trial and error, i managed to find out which version of Go is needed. Also i tested running compilation command using Go provided by Debian repository and it worked fine -- no need to taint system with Snaps, if user doesn't have any.