### PR TITLE
prevent server.go PlayerUnit crash on server mode

### DIFF
--- a/src/server.go
+++ b/src/server.go
@@ -383,8 +383,10 @@ func (s *Server) nox_xxx_gameTick_4D2580_server_E() {
 	s.maybeCallMapInit()
 	s.maybeCallMapEntry()
 	s.abilities.sub_4FC680()
-	if unit := s.Players.ByInd(server.HostPlayerIndex).PlayerUnit; unit != nil {
-		s.spells.walls.associateSavedWalls(unit)
+	if playerInd := s.Players.ByInd(server.HostPlayerIndex); playerInd != nil {
+		if unit := playerInd.PlayerUnit; unit != nil {
+			s.spells.walls.associateSavedWalls(unit)
+		}
 	}
 	if legacy.Nox_xxx_get_57AF20() != 0 && legacy.Sub_57B140() {
 		legacy.Sub_57B0A0()


### PR DESCRIPTION
when launching opennox-server, `s.Players.ByInd(server.HostPlayerIndex)` is nil. this additional check prevents a segfault

## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.