### PR TITLE
Directed manual casting

### DIFF
--- a/src/client.go
+++ b/src/client.go
@@ -72,6 +72,7 @@ type Client struct {
 	dword_5d4594_1046604   int
 	tsFullPRev             uint32
 	tsUpperPrev            uint32
+	ManualCastDirectionInverted bool
 }
 
 func (c *Client) Cli() *client.Client {

--- a/src/object_update.go
+++ b/src/object_update.go
@@ -110,6 +110,7 @@ func nox_xxx_updatePlayer_4F8100(u *server.Object) {
 		}
 	}
 	if ud.SpellCastStart != 0 && ud.Field47_0 == 0 && (s.Frame()-ud.SpellCastStart) > spellTimeout {
+		s.UpdateSpellTargetForManualCast(u)
 		s.PlayerSpell(u) // (manual?) spell casting
 		ud.SpellCastStart = 0
 	}
@@ -579,6 +580,7 @@ func (s *Server) unitUpdatePlayerImplB(u *server.Object, a1, v68 bool) {
 			nox_xxx_playerSetState_4FA020(u, server.PlayerState13)
 			if !noxflags.HasGame(noxflags.GameModeChat) {
 				if ud.SpellCastStart != 0 {
+					s.UpdateSpellTargetForManualCast(u)
 					s.PlayerSpell(u)
 					ud.SpellCastStart = 0
 				} else {
@@ -590,6 +592,7 @@ func (s *Server) unitUpdatePlayerImplB(u *server.Object, a1, v68 bool) {
 			nox_xxx_playerSetState_4FA020(u, server.PlayerState13)
 			if !noxflags.HasGame(noxflags.GameModeChat) {
 				if ud.SpellCastStart != 0 {
+					s.UpdateSpellTargetForManualCast(u)
 					s.PlayerSpell(u)
 					ud.SpellCastStart = 0
 				}
@@ -601,6 +604,7 @@ func (s *Server) unitUpdatePlayerImplB(u *server.Object, a1, v68 bool) {
 		case player.CCCastMostRecentSpell:
 			if !noxflags.HasGame(noxflags.GameModeChat) {
 				if ud.SpellCastStart != 0 {
+					s.UpdateSpellTargetForManualCast(u)
 					s.PlayerSpell(u)
 					ud.SpellCastStart = 0
 				}

--- a/src/object_update.go
+++ b/src/object_update.go
@@ -110,7 +110,6 @@ func nox_xxx_updatePlayer_4F8100(u *server.Object) {
 		}
 	}
 	if ud.SpellCastStart != 0 && ud.Field47_0 == 0 && (s.Frame()-ud.SpellCastStart) > spellTimeout {
-		s.UpdateSpellTargetForManualCast(u)
 		s.PlayerSpell(u) // (manual?) spell casting
 		ud.SpellCastStart = 0
 	}
@@ -580,7 +579,6 @@ func (s *Server) unitUpdatePlayerImplB(u *server.Object, a1, v68 bool) {
 			nox_xxx_playerSetState_4FA020(u, server.PlayerState13)
 			if !noxflags.HasGame(noxflags.GameModeChat) {
 				if ud.SpellCastStart != 0 {
-					s.UpdateSpellTargetForManualCast(u)
 					s.PlayerSpell(u)
 					ud.SpellCastStart = 0
 				} else {
@@ -592,7 +590,6 @@ func (s *Server) unitUpdatePlayerImplB(u *server.Object, a1, v68 bool) {
 			nox_xxx_playerSetState_4FA020(u, server.PlayerState13)
 			if !noxflags.HasGame(noxflags.GameModeChat) {
 				if ud.SpellCastStart != 0 {
-					s.UpdateSpellTargetForManualCast(u)
 					s.PlayerSpell(u)
 					ud.SpellCastStart = 0
 				}
@@ -604,7 +601,6 @@ func (s *Server) unitUpdatePlayerImplB(u *server.Object, a1, v68 bool) {
 		case player.CCCastMostRecentSpell:
 			if !noxflags.HasGame(noxflags.GameModeChat) {
 				if ud.SpellCastStart != 0 {
-					s.UpdateSpellTargetForManualCast(u)
 					s.PlayerSpell(u)
 					ud.SpellCastStart = 0
 				}

--- a/src/player.go
+++ b/src/player.go
@@ -71,6 +71,34 @@ func (s *Server) PlayerSetPos(p *Player, pos types.Pointf) {
 	asObjectS(u).SetPos(pos)
 }
 
+func (s * Server) UpdateSpellTargetForManualCast(u *server.Object) {
+	ud := u.UpdateDataPlayer()
+	pl := ud.Player
+	
+	pl.Obj3640 = s.GetSpellTargetForManualCast(u)
+}
+
+func (s * Server) GetSpellTargetForManualCast(u *server.Object) *server.Object{
+	ud := u.UpdateDataPlayer()
+	cursor_obj := ud.CursorObj
+	pl := ud.Player
+	
+	if leaf := ud.SpellPhonemeLeaf; leaf == s.Spells.PhonemeTree() {
+		return pl.Obj3640
+	} else if leaf != nil && leaf.Ind != 0 {
+		spellInd := spell.ID(leaf.Ind)
+		
+		if s.Spells.HasFlags(spellInd, things.SpellOffensive) {
+			if(cursor_obj == nil){
+			}
+			return cursor_obj
+		} else {
+			return u
+		}
+	}
+	return pl.Obj3640
+}
+
 func (s *Server) PlayerPrint(p *Player, text string) {
 	legacy.Nox_xxx_netSendLineMessage_4D9EB0(p.PlayerUnit, text)
 }

--- a/src/player.go
+++ b/src/player.go
@@ -71,32 +71,43 @@ func (s *Server) PlayerSetPos(p *Player, pos types.Pointf) {
 	asObjectS(u).SetPos(pos)
 }
 
-func (s * Server) UpdateSpellTargetForManualCast(u *server.Object) {
+// Hepler function to update the player's spell target.
+// This is called before s.PlayerSpell(u) in manual-casting-related sections of the code.
+func (s *Server) UpdateSpellTargetForManualCast(u *server.Object) {
 	ud := u.UpdateDataPlayer()
 	pl := ud.Player
-	
+
 	pl.Obj3640 = s.GetSpellTargetForManualCast(u)
 }
 
-func (s * Server) GetSpellTargetForManualCast(u *server.Object) *server.Object{
+// Determine which object should be used as the players spell target
+func (s *Server) GetSpellTargetForManualCast(u *server.Object) *server.Object {
 	ud := u.UpdateDataPlayer()
 	cursor_obj := ud.CursorObj
 	pl := ud.Player
+
+	// This logic primarily follows the logic from the server.PlayerSpell(u) function to determine the target
+	// TODO: Use the state of the Shift(InvertSpellTarget) key to toggle the spell's direction, instead of going by the object under the cursor
 	if leaf := ud.SpellPhonemeLeaf; leaf != nil && leaf.Ind != 0 {
 		spellInd := spell.ID(leaf.Ind)
-		
+
+		// Offensive spells target the object under the cursor if found
+		// Otherwise, a value of `nil` sends the spell into the environment, leaving it to find the closest target
 		if s.Spells.HasFlags(spellInd, things.SpellOffensive) {
-			if(cursor_obj != nil){
+			if cursor_obj != nil {
 				return cursor_obj
 			}
 			return nil
 		} else {
-			if(cursor_obj != nil){
+			// Defensive spells target the object under the cursor if found
+			// Otherwise, the player is targeted.
+			if cursor_obj != nil {
 				return cursor_obj
 			}
 			return u
 		}
 	}
+	// If all else fails, return the player's current spell target
 	return pl.Obj3640
 }
 

--- a/src/player.go
+++ b/src/player.go
@@ -82,10 +82,7 @@ func (s * Server) GetSpellTargetForManualCast(u *server.Object) *server.Object{
 	ud := u.UpdateDataPlayer()
 	cursor_obj := ud.CursorObj
 	pl := ud.Player
-	
-	if leaf := ud.SpellPhonemeLeaf; leaf == s.Spells.PhonemeTree() {
-		return pl.Obj3640
-	} else if leaf != nil && leaf.Ind != 0 {
+	if leaf := ud.SpellPhonemeLeaf; leaf != nil && leaf.Ind != 0 {
 		spellInd := spell.ID(leaf.Ind)
 		
 		if s.Spells.HasFlags(spellInd, things.SpellOffensive) {

--- a/src/player.go
+++ b/src/player.go
@@ -89,10 +89,14 @@ func (s * Server) GetSpellTargetForManualCast(u *server.Object) *server.Object{
 		spellInd := spell.ID(leaf.Ind)
 		
 		if s.Spells.HasFlags(spellInd, things.SpellOffensive) {
-			if(cursor_obj == nil){
+			if(cursor_obj != nil){
+				return cursor_obj
 			}
-			return cursor_obj
+			return nil
 		} else {
+			if(cursor_obj != nil){
+				return cursor_obj
+			}
 			return u
 		}
 	}

--- a/src/server/player.go
+++ b/src/server/player.go
@@ -687,7 +687,7 @@ type Player struct {
 	field3624           uint32         // 906, 3624
 	CameraFollowObj     *Object        // 907, 3628
 	Pos3632Vec          types.Pointf   // 908, 3632
-	Obj3640             *Object        // 910, 3640
+	Obj3640             *Object        // 910, 3640, object that is set as spell target when casting from the spell bar
 	Journal             *PlayerJournal // 911, 3644, pointer to journal
 	SummonOrderAll      uint32         // 912, 3648
 	field3652           uint32


### PR DESCRIPTION
Before this change, manual spell casting used the target object from the last spell the player cast from the spell bar. Which meant that time and time again, various buffs were getting cast on enemies instead of you, and it was tricky to cast spells that would heal allies.

Ideally, when manual casting, defensive spells would default to targeting you, offensive spells would default to targeting enemies, and Shift/`CCInvertSpellTarget` key would be used to change that default. (so the sequence `Do`, `Un`, `Ro`, `Shift` would cast Lesser Heal towards others) However, the input handling code that is used to handle pressing shift, does not have access to the player object to easily be able to update the spell target. 

For the time being, I have made the following workaround. It's not as explicit as I would like, as you can't heal yourself when there's an object under the cursor, but it fits the needs.
When manual casting:
* defensive spells by default are targeted at the player,
* offensive spells by default are targeted away from the player
* if there is an object under the cursor when the manual casting timeout is reached, it is set as the spell target instead.

## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.
