### PR TITLE
Ignore vscode IDE configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ src/cmake-build-*
 
 # For VS IDE
 .vs/
+.vscode/
 
 # Omit external libraries
 src/external


### PR DESCRIPTION
As I don't have GoLand license, I'd like to use vscode(or its fork) for the development. I managed to make it work with CGO enabled, but don't like to see those IDE specific configs to show up in the commit candidate list.

## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.
