### PR TITLE
Declare dword_587000_93160

### DIFF
--- a/src/audio_ail.go
+++ b/src/audio_ail.go
@@ -249,7 +249,7 @@ func nox_xxx_musicStartPlay_43D6C0(a1p unsafe.Pointer) int {
 	}
 	aname := audioTable[ind]
 	sub_43D650()
-	*memmap.PtrUint32(0x587000, 93160) = 0
+	legacy.Set_dword_587000_93160(0)
 	path := filepath.Join("music", aname)
 	if !strings.Contains(path, ".") {
 		path += ".wav"
@@ -263,7 +263,7 @@ func nox_xxx_musicStartPlay_43D6C0(a1p unsafe.Pointer) int {
 		if v5 == "" {
 			return 0
 		}
-		*memmap.PtrUint32(0x587000, 93160) = 1
+		legacy.Set_dword_587000_93160(1)
 		path2 := filepath.Join(v5, path)
 		s = legacy.Get_dword_5d4594_816376().OpenStream(path2, 204800)
 		if s == 0 {

--- a/src/legacy/GAME2.c
+++ b/src/legacy/GAME2.c
@@ -50,6 +50,7 @@
 #include "common__magic__speltree.h"
 #include "input_common.h"
 
+extern uint32_t dword_587000_93160;
 extern uint32_t dword_8531A0_2576;
 extern uint32_t dword_5d4594_1046852;
 extern uint32_t dword_5d4594_1045576;
@@ -225,7 +226,7 @@ void sub_44D3A0() {
 		if (dword_5d4594_830872 && dword_587000_122848) {
 			if (!sub_44D660(*(const char**)&dword_5d4594_830872)) {
 				dword_5d4594_830872 = 0;
-			} else if (!dword_587000_122856 || !*getMemU32Ptr(0x587000, 93160) || dword_5d4594_831084) {
+			} else if (!dword_587000_122856 || !dword_587000_93160 || dword_5d4594_831084) {
 				dword_5d4594_830864 = 2;
 			} else {
 				dword_5d4594_831084 = 1;

--- a/src/legacy/vardefs.c
+++ b/src/legacy/vardefs.c
@@ -137,6 +137,7 @@ uint32_t dword_5d4594_1046924 = 0;
 uint32_t nox_xxx_polygonNextAngle_587000_60356 = 0x1;
 uint32_t dword_5d4594_1307716 = 0;
 uint32_t dword_587000_93156 = 0x1;
+uint32_t dword_587000_93160 = 0x1;
 uint32_t dword_5d4594_2523780 = 0;
 uint32_t dword_5d4594_2650676 = 0;
 uint32_t dword_5d4594_1321252 = 0;

--- a/src/legacy/vardefs.go
+++ b/src/legacy/vardefs.go
@@ -134,6 +134,7 @@ extern uint32_t dword_5d4594_1046924;
 extern uint32_t nox_xxx_polygonNextAngle_587000_60356;
 extern uint32_t dword_5d4594_1307716;
 extern uint32_t dword_587000_93156;
+extern uint32_t dword_587000_93160;
 extern uint32_t dword_5d4594_2523780;
 extern uint32_t dword_5d4594_2650676;
 extern uint32_t dword_5d4594_1321252;
@@ -881,6 +882,12 @@ func Get_dword_5d4594_816340() int {
 }
 func Get_dword_587000_93156() int {
 	return int(C.dword_587000_93156)
+}
+func Get_dword_587000_93160() int {
+	return int(C.dword_587000_93160)
+}
+func Set_dword_587000_93160(v int) {
+	C.dword_587000_93160 = C.uint(v)
 }
 func Get_dword_5d4594_816348() int {
 	return int(C.dword_5d4594_816348)


### PR DESCRIPTION
Context: I'm working on interpreting sub_44D3A0 which I believe to be dialog system's update function, and want to remove this memory map access for clarity.

There are dword_587000_93156 and 93164, so I believe 93160 is 4-byte width single value.

Initial value was from adhoc reading memory map.

<!--
Describe what your PR changes and why. Please link related issues.

Make sure to split large changes into separate commits to allow bisecting in the future.

Ideally each commit should include one of the following (but not everything at once!):

- Rename of variables/functions.
- Rename of struct fields.
- Fixes to function signatures.
- Reconstruction of data structures.
- Reconstruction of functions.
-->


## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.
