### PR TITLE
Fix the invalid pointer check

### DIFF
--- a/src/lists.go
+++ b/src/lists.go
@@ -59,7 +59,7 @@ func (l *listItem) Next() *listItem {
 		return nil
 	}
 	it := l.next
-	if it == l.head {
+	if it == it.head {
 		return nil
 	}
 	return it


### PR DESCRIPTION
Current Go code is not equivalent with corresponding C code: https://github.com/noxworld-dev/opennox/blob/dev/src/legacy/GAME1_1.c#L5178

Logical explanation:

Only the listHead is guaranteed to have field_2 set to itself, while list members does not have such guarantee. So the best way to check the listItem is to check the current pointer is same with field_2 (or head)

## Required sign-off

- [x] I confirm that my PR does not contain any commercial or protected assets and/or source code.
- [x] I agree in advance that my codes will be licensed automatically under the Apache License or similar BSD/MIT-like
      open source licenses in case if OpenNox Project will adopt such a non-GPL license in the future.
